### PR TITLE
sysfs: set output() value to 0 or 1

### DIFF
--- a/OPi/sysfs.py
+++ b/OPi/sysfs.py
@@ -46,9 +46,9 @@ def input(pin):
 
 
 def output(pin, value):
-    assert value in [HIGH, LOW]
+    str_value = "1" if value else "0"
     with value_descriptor(pin, "w") as fp:
-        fp.write(str(value))
+        fp.write(str_value)
 
 
 def edge(pin, trigger):


### PR DESCRIPTION
Use a string value of "0" or "1" rather than creating a string object
from value. Boolean values pass the assert() but result in an Invalid
argument from the kernel.