### PR TITLE
Expose the pullup resistor constants to API users.

### DIFF
--- a/OPi/GPIO.py
+++ b/OPi/GPIO.py
@@ -244,6 +244,7 @@ from OPi.constants import IN, OUT
 from OPi.constants import LOW, HIGH                     # noqa: F401
 from OPi.constants import NONE, RISING, FALLING, BOTH   # noqa: F401
 from OPi.constants import BCM, BOARD, SUNXI, CUSTOM
+from OPi.constants import PUD_UP, PUD_DOWN, PUD_OFF
 from OPi.pin_mappings import get_gpio_pin, set_custom_pin_mappings
 from OPi import event, sysfs
 


### PR DESCRIPTION
These weren't being exposed as part of the GPIO module, so callers
were getting error messages like this:

$ python ../gpio_button_edge_detect.py
Traceback (most recent call last):
  File "../gpio_button_edge_detect.py", line 11, in <module>
    GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
AttributeError: module 'OPi.GPIO' has no attribute 'PUD_DOWN'