### PR TITLE
Add (almost) all current Orange Pi devices

### DIFF
--- a/orangepi/lite.py
+++ b/orangepi/lite.py
@@ -20,8 +20,8 @@ Usage:
 
 import orangepi.pc
 
-# Orange Pi One physical board pin to GPIO pin
+# Orange Pi Lite physical board pin to GPIO pin
 BOARD = orangepi.pc.BOARD
 
-# Orange Pi One BCM pin to actual GPIO pin
+# Orange Pi Lite BCM pin to actual GPIO pin
 BCM = orangepi.pc.BCM

--- a/orangepi/lite2.py
+++ b/orangepi/lite2.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI Lite 2
+(see http://linux-sunxi.org/images/4/4c/OrangePi_Lite2_Schematics_v2.0.pdf)
+
+Usage:
+
+.. code:: python
+   import orangepi.lite2
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.lite2.BOARD) or GPIO.setmode(orangepi.lite2.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+import orangepi.oneplus
+
+# Orange Pi Lite 2 physical board pin to GPIO pin
+BOARD = orangepi.oneplus.BOARD
+
+# Orange Pi Lite 2 BCM pin to actual GPIO pin
+BCM = orangepi.oneplus.BCM

--- a/orangepi/oneplus.py
+++ b/orangepi/oneplus.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI One Plus
+(https://linux-sunxi.org/images/7/7c/OrangePi_OnePlus_Schematics_v2.0.pdf)
+
+Usage:
+
+.. code:: python
+   import orangepi.oneplus
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.oneplus.BOARD) or GPIO.setmode(orangepi.oneplus.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+# Orange Pi One Plus physical board pin to GPIO pin
+BOARD = {
+    3:  230,    # PH6/SPI1-MISO/SPDIF-IN/TWI1-SDA/SIM1-DET
+    5:  229,    # PH5/SPI1-MOSI/SPDIF-MCLK/TWI1-SCK/SIM1-RST
+    7:  228,    # PH4/SPI1-CLK/PCM0-MCLK/H-PCM0-MCLK/SIM1-DATA/PWM1
+    8:  117,    # PD21/LCD0-VSYNC/TS2-D0/UART2-RTS
+    10: 118,    # PD22/PWM0/TS3-CLK/UART2-CTS
+    11: 120,    # PD24/TWI2-SDA/TS3-SYNC/UART3-RX/JTAG-CK
+    12:  73,    # PC9/NAND-DQ3/SDC2-D3
+    13: 119,    # PD23/TWI2-SCK/TS3-ERR/UART3-TX/JTAG-MS
+    15: 122,    # PD26/TWI0-SDA/TS3-D0/UART3-CTS/JTAG-DI
+    16:  72,    # PC8/NAND-DQ2/SDC2-D2
+    18:  71,    # PC7/NAND-DQ1/SDC2-D1/SPI0-WP
+    19:  66,    # PC2/NAND-CLE/SPI0-MOSI
+    21:  67,    # PC3/NAND-CE0/SPI0-MISO
+    22: 121,    # PD25/TWI0-SCK/TS3-DVLD/UART3-RTS/JTAG-DO
+    23:  64,    # PC0/NAND-WE/SPI0-CLK
+    24:  69,    # PC5/NAND-RB0/SDC2-CMD/SPI0-CS
+    26: 227     # PH3/SPI1-CS/PCM0-DIN/H-PCM0-DIN/SIM1-CLK
+}
+
+# No reason for BCM mapping, keeping it for compatibility
+BCM = BOARD

--- a/orangepi/pc2.py
+++ b/orangepi/pc2.py
@@ -1,0 +1,50 @@
+"""
+Alternative pin mappings for Orange PI PC 2(
+https://linux-sunxi.org/images/c/cb/ORANGE_PI-PC2-V1_2_schematic.pdf
+)
+
+Usage:
+
+.. code:: python
+   import orangepi.pc2
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.pc2.BOARD)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be 3 * 32 +14 = 110
+
+BOARD = {
+    3:   12,    # PA12/TWI0_SDA/DI_RX/PA_EINT12
+    5:   11,    # PA11/TWI0_SCK/DI_TX/PA_EINT11
+    7:    6,    # PA6/SIM_PWREN/PWM1/PA_EINT6
+    8:   69,    # PC5/NAND_RE/SDC2_CLK
+    10:  70,    # PC6/NAND_RB0/SDC2_CMD
+    11:   1,    # PA1/UART2_RX/JTAG_CK0/PA_EINT1
+    12: 110,    # PD14/RGMII_NULL/MII_TXERR/RMII_NULL
+    13:   0,    # PA0/UART2_TX/JTAG_MS0/PA_EINT0
+    15:   3,    # PA3/UART2_CTS/JTAG_DI0/PA_EINT3
+    16:  68,    # PC4/NAND_CE0
+    18:  71,    # PC7/NAND_RB1
+    19:  15,    # PA15/SPI1_MOSI/UART3_RTS/PA_EINT15
+    21:  16,    # PA16/SPI1_MISO/UART3_CTS/PA_EINT16
+    22:   2,    # PA2/UART2_RTS/JTAG_DO0/PA_EINT2
+    23:  14,    # PA14/SPI1_CLK/UART3_RX/PA_EINT14
+    24:  13,    # PA13/SPI1_CS/UART3_TX/PA_EINT13
+    26:  21,    # PA21/PCM0_DIN/SIM_VPPPP/PA_EINT21
+    27:  19,    # PA19/PCM0_CLK/TWI1_SDA/PA_EINT19
+    28:  18,    # PA18/PCM0_SYNC/TWI1_SCK/PA_EINT18
+    29:   7,    # PA7/SIM_CLK/PA_EINT7
+    31:   8,    # PA8/SIM_DATA/PA_EINT8
+    32: 200,    # PG8/UART1_RTS/PG_EINT8
+    33:   9,    # PA9/SIM_RST/PA_EINT9
+    35:  10,    # PA10/SIM_DET/PA_EINT10
+    36: 201,    # PG9/UART1_CTS/PG_EINT9
+    37: 107,    # PD11/RGMII_NULL/MII_CRS/RMII_NULL
+    38: 198,    # PG6/UART1_TX/PG_EINT6
+    40: 199,    # PG7/UART1_RX/PG_EINT7
+}
+
+# No reason for BCM mapping, keeping it for compatibility
+BCM = BOARD

--- a/orangepi/pcplus.py
+++ b/orangepi/pcplus.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI PC Plus
+(see orange_pi-pc_plus_v1_1 schemetic.pdf document from Orange Pi Website
+no direct link)
+
+Usage:
+
+.. code:: python
+   import orangepi.pcplus
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.pcplus.BOARD) or GPIO.setmode(orangepi.pcplus.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+import orangepi.pc
+
+# Orange Pi PC Plus physical board pin to GPIO pin
+BOARD = orangepi.pc.BOARD
+
+# Orange Pi PC Plus BCM pin to actual GPIO pin
+BCM = orangepi.pc.BCM

--- a/orangepi/pi3.py
+++ b/orangepi/pi3.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI 3
+(https://linux-sunxi.org/images/5/50/OrangePi_3_Schematics_v1.5.pdf)
+
+Usage:
+
+.. code:: python
+   import orangepi.3
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.3.BOARD) or GPIO.setmode(orangepi.3.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+# Orange Pi 3 physical board pin to GPIO pin
+BOARD = {
+    3:  122,    # PD26/TWI0-SDA/TS3-D0/UART3-CTS/JTAG-DI
+    5:  121,    # PD25/TWI0-SCK/TS3-DVLD/UART3-RTS/JTAG-DO
+    7:  118,    # PD22/PWM0/TS3-CLK/UART2-CTS
+    8:  354,    # PL2/S-UART-TX
+    10: 355,    # PL3/S-UART-RX
+    11: 120,    # PD24/TWI2-SDA/TS3-SYNC/UART3-RX/JTAG-CK
+    12: 114,    # PD18/LCD0-CLK/TS2-ERR/DMIC-DATA3
+    13: 119,    # PD23/TWI2-SCK/TS3-ERR/UART3-TX/JTAG-MS
+    15: 362,    # PL10/S-OWC/S-PWM1
+    16: 111,    # PD15/LCD0-D21/TS1-DVLD/DMIC-DATA0/CSI-D9
+    18: 112,    # PD16/LCD0-D22/TS1-D0/DMIC-DATA1
+    19: 229,    # PH5/SPI1-MOSI/SPDIF-MCLK/TWI1-SCK/SIM1-RST
+    21: 230,    # PH6/SPI1-MISO/SPDIF-IN/TWI1-SDA/SIM1-DET
+    22: 117,    # PD21/LCD0-VSYNC/TS2-D0/UART2-RTS
+    23: 228,    # PH4/SPI1-CLK/PCM0-MCLK/H-PCM0-MCLK/SIM1-DATA
+    24: 227,    # PH3/SPI1-CS/PCM0-DIN/H-PCM0-DIN/SIM1-CLK
+    26: 360     # PL8/S-PWM0
+}
+
+# No reason for BCM mapping, keeping it for compatibility
+BCM = BOARD

--- a/orangepi/plus2e.py
+++ b/orangepi/plus2e.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI Plus 2E
+(see https://linux-sunxi.org/images/0/03/Orangepi-plus-2e-v1_1-schematic.pdf)
+
+Usage:
+
+.. code:: python
+   import orangepi.plus2e
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.plus2e.BOARD) or GPIO.setmode(orangepi.plus2e.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+import orangepi.pc
+
+# Orange Pi One physical board pin to GPIO pin
+BOARD = orangepi.pc.BOARD
+
+# Orange Pi One BCM pin to actual GPIO pin
+BCM = orangepi.pc.BCM

--- a/orangepi/prime.py
+++ b/orangepi/prime.py
@@ -18,10 +18,36 @@ Usage:
 # pin number = (position of letter in alphabet - 1) * 32 + pin number
 # So, PD14 will be (4 - 1) * 32 + 14 = 110
 
-import orangepi.pc
+BOARD = {
+    3:   12,    # PA12/TWI0_SDA/DI_RX/PA_EINT12
+    5:   11,    # PA11/TWI0_SCK/DI_TX/PA_EINT11
+    7:    6,    # PA6/SIM_PWREN/PWM1/PA_EINT6
+    8:   69,    # PC5/NAND_RE/SDC2_CLK
+    10:  70,    # PC6/NAND_RB0/SDC2_CMD
+    11:   1,    # PA1/UART2_RX/JTAG_CK0/PA_EINT1
+    12: 110,    # PD14/RGMII_NULL/MII_TXERR/RMII_NULL
+    13:   0,    # PA0/UART2_TX/JTAG_MS0/PA_EINT0
+    15:   3,    # PA3/UART2_CTS/JTAG_DI0/PA_EINT3
+    16:  68,    # PC4/NAND_CE0
+    18:  71,    # PC7/NAND_RB1
+    19:  15,    # PA15/SPI1_MOSI/UART3_RTS/PA_EINT15
+    21:  16,    # PA16/SPI1_MISO/UART3_CTS/PA_EINT16
+    22:   2,    # PA2/UART2_RTS/JTAG_DO0/PA_EINT2
+    23:  14,    # PA14/SPI1_CLK/UART3_RX/PA_EINT14
+    24:  13,    # PA13/SPI1_CS/UART3_TX/PA_EINT13
+    26:  72,    # PC8/NAND_DQ0/SDC2_D0
+    27:  19,    # PA19/PCM0_CLK/TWI1_SDA/PA_EINT19
+    28:  18,    # PA18/PCM0_SYNC/TWI1_SCK/PA_EINT18
+    29:   7,    # PA7/SIM_CLK/PA_EINT7
+    31:   8,    # PA8/SIM_DATA/PA_EINT8
+    32:  73,    # PC9/NAND_DQ1/SDC2_D1
+    33:   9,    # PA9/SIM_RST/PA_EINT9
+    35:  10,    # PA10/SIM_DET/PA_EINT10
+    36:  74,    # PC10/NAND_DQ2/SDC2_D2
+    37: 107,    # PD11/RGMII_NULL/MII_CRS/RMII_NULL
+    38:  75,    # PC11/NAND_DQ3/SDC2_D3
+    40:  76,    # PC12/NAND_DQ4/SDC2_D4
+}
 
-# Orange Pi One physical board pin to GPIO pin
-BOARD = orangepi.pc.BOARD
-
-# Orange Pi One BCM pin to actual GPIO pin
-BCM = orangepi.pc.BCM
+# No reason for BCM mapping, keeping it for compatibility
+BCM = BOARD

--- a/orangepi/r1.py
+++ b/orangepi/r1.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI R1
+(see ORANGE_PI-R1-V1_1_Schematic.pdf document from Orange Pi Website
+no direct link)
+
+Usage:
+
+.. code:: python
+   import orangepi.r1
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.r1.BOARD) or GPIO.setmode(orangepi.r1.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+import orangepi.zeroplus
+
+# Orange Pi R1 physical board pin to GPIO pin
+BOARD = orangepi.zeroplus.BOARD
+
+# Orange Pi R1 BCM pin to actual GPIO pin
+BCM = orangepi.zeroplus.BCM

--- a/orangepi/winplus.py
+++ b/orangepi/winplus.py
@@ -1,0 +1,50 @@
+"""
+Alternative pin mappings for Orange PI WinPlus(
+https://linux-sunxi.org/images/6/6c/ORANGEPI-Winplus-V1_3.pdf
+)
+
+Usage:
+
+.. code:: python
+   import orangepi.winplus
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.winplus.BOARD)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be 3 * 32 +14 = 110
+
+BOARD = {
+    3:  227,    # PH3/TWI1-SDA
+    5:  226,    # PH2/TWI1-SCK
+    7:  362,    # PL10/S-PWM
+    8:  354,    # PL2/S-UART-TX
+    10: 355,    # PL3/S-UART-RX
+    11: 229,    # PH5/UART3-RX
+    12: 100,    # PD4/LCD-D6/UART4-RTS/CCIR-D0
+    13: 228,    # PH4/UART3-TX
+    15: 231,    # PH7/UART3-CTS
+    16: 361,    # PL9/S-TWI-SDA
+    18:  68,    # PC4/NAND-CE0
+    19:  98,    # PD2/LCD-D4/UART4-TX/SPI1-MOSI/CCIR-HSYNC
+    21:  99,    # PD3/LCD-D5/UART4-RX/SPI1-MISO/CCIR-VSYNC
+    22: 230,    # PH6/UART3-RTS
+    23:  97,    # PD1/LCD-D3/UART3-RX/SPI1-CLK/CCIR-DE
+    24:  96,    # PD0/LCD-D2/UART3-TX/SPI1-CS/CCIR-CLK
+    26: 102,    # PD6/LCD-D10/CCIR-D2
+    27: 143,    # PE15/TWI2-SDA
+    28: 142,    # PE14/PLL-LOCK-DBG/TWI2-SCK
+    29:  36,    # PB4/AIF2-SYNC/PCM0-SYNC
+    31:  37,    # PB5/AIF2-BCLK/PCM0-BCLK
+    32:  34,    # PB2/UART2-RTS/JTAG-DO0
+    33:  38,    # PB6/AIF2-DOUT/PCM0-DOUT
+    35:  39,    # PB7/AIF2-DINPCM0-DIN
+    36:  35,    # PB3/UART2-CTS/I2S0-MCLK/JTAG-DI0
+    37: 101,    # PD5/LCD-D7/UART4-CTS/CCIR-D1
+    38:  32,    # PB0/UART2-TX/JTAG-MS0
+    40:  33,    # PB1/UART2-RX/JTAG-CK0
+}
+
+# No reason for BCM mapping, keeping it for compatibility
+BCM = BOARD

--- a/orangepi/zero.py
+++ b/orangepi/zero.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Richard Hull & Contributors
+# See LICENSE.md for details.
+
+"""
+Alternative pin mappings for Orange PI Zero
+(see https://linux-sunxi.org/images/e/e0/Orange-Pi-Zero-Schanetics-v1_11.pdf)
+
+Usage:
+
+.. code:: python
+   import orangepi.zero
+   from OPi import GPIO
+
+   GPIO.setmode(orangepi.zero.BOARD) or GPIO.setmode(orangepi.zero.BCM)
+"""
+
+# pin number = (position of letter in alphabet - 1) * 32 + pin number
+# So, PD14 will be (4 - 1) * 32 + 14 = 110
+
+import orangepi.zeroplus
+
+# Orange Pi Zero physical board pin to GPIO pin
+BOARD = orangepi.zeroplus.BOARD
+
+# Orange Pi Zero BCM pin to actual GPIO pin
+BCM = orangepi.zeroplus.BCM


### PR DESCRIPTION
As there are now lots of Orange Pi devices, I tried to support them all. I limited myself to all devices with Allwinner chips (H2+/H3/H5/H6/A64).

I added 4 new pin mappings and 5 placeholders (for devices which use the same mapping as another). Also fixed the mappings for Orange Pi Prime as these seemed to be incorrect according to schematics.

No documentation for the Orange Pi Zero LTS is available, however I highly suspect it follows the Orange Pi Zero mapping. Users can test if using mode `zero` works for their Zero LTS.
Also no documentation for the Orange Pi Zero Plus 2 (H3-variant) exists. I don't want to make a guess which mapping this device uses, as the board lay-out is very similar to its H5 brother, but the H3 is very different.

Also note that a lot of the Orange Pi manuals show different mappings then their schematics. I suspect they copy these manuals from device to device and search and replace some strings. One clear example is that pin PC2 was replaced by pin 'Plus 2E' (note that PC2 is also a device name). So for every device I used its schematics as the base for the mappings instead of the manuals.

This also means that, besides the Orange Pi PC which I own myself, every other device is untested. However I triple checked everything to make sure it was correctly following the schematics.

Below is the full list of Orange Pi devices I could find with their mapping file:
```
H2+:
Orange Pi Zero (H2+) = zeroplus
Orange Pi Zero LTS (H2+) = ?zeroplus?
Orange Pi R1 (H2+) = zeroplus

H3:
Orange Pi One (H3) = pc
Orange Pi Lite (H3) = pc
Orange Pi PC (H3) = pc
Orange Pi PC Plus (H3) = pc
Orange Pi Plus 2E (H3) = pc
Orange Pi Zero Plus 2 (H3) = ?

H5:
Orange Pi PC 2 (H5) = pc2
Orange Pi Prime (H5) = prime
Orange Pi Zero Plus (H5) = zeroplus
Orange Pi Zero Plus 2 (H5) = zeroplus2

H6:
Orange Pi One Plus (H6) = oneplus
Orange Pi Lite 2 (H6) = oneplus
Orange Pi 3 (H6) = pi3

A64:
Orange Pi WinPlus (A64) = winplus

Other:
Orange Pi RK3399 (RK3399) = ?
Orange Pi 4G-IOT (MT6737) = ?
Orange Pi 3G-IOT (MT6572) = ?
Orange Pi 2G-IOT (RDA8810) = ?
Orange Pi i96 (RDA8810) = ?
```