### PR TITLE
Added Hardware PWM Control

### DIFF
--- a/Demo/PWM_Demo.py
+++ b/Demo/PWM_Demo.py
@@ -1,0 +1,47 @@
+import OPi.GPIO as GPIO
+
+if __name__ == "__main__":
+
+    GPIO.setmode(GPIO.BOARD)
+    PWM_pin = 0
+    frequency_Hz = 3800
+    Duty_Cycle_Percent = 100
+
+    p = GPIO.PWM(PWM_pin, frequency_Hz, Duty_Cycle_Percent)    # new PWM on channel=LED_gpio frequency=38KHz
+    
+    print("turn on pwm by pressing button")
+    input()
+    p.start_pwm()
+
+    print("dimm pwm by pressing button")
+    input()
+    p.duty_cycle(50)
+    
+    print("change pwm frequency by pressing button")
+    input()
+    p.change_frequency(500)
+
+    print("stop pwm by reducing duty cycle to 0 by pressing button")
+    input()
+    p.stop_pwm()
+
+    print("change polarity by pressing button")
+    input()   
+    p.pwm_polarity()
+
+    print("increase duty cycle but inverted so light will dim. press button to contunue")
+    input()
+    p.duty_cycle(75)
+
+    print("duty cycle reduced press button to contunue")
+    input()
+    p.duty_cycle(25)
+
+    print("stop pwm (it was inverted so it shoudl be full brightness), press button to contunue")
+    input()   
+    p.stop_pwm()
+
+    print("remove object and deactivate pwm pin, press button to contunue")
+    input()
+    p.pwm_close()
+    del p #delete the class

--- a/Demo/PWM_Demo.py
+++ b/Demo/PWM_Demo.py
@@ -2,13 +2,13 @@ import OPi.GPIO as GPIO
 
 if __name__ == "__main__":
 
-    GPIO.setmode(GPIO.BOARD)
+    PWM_chip = 0
     PWM_pin = 0
     frequency_Hz = 3800
     Duty_Cycle_Percent = 100
 
-    p = GPIO.PWM(PWM_pin, frequency_Hz, Duty_Cycle_Percent)    # new PWM on channel=LED_gpio frequency=38KHz
-    
+    p = GPIO.PWM(PWM_chip, PWM_pin, frequency_Hz, Duty_Cycle_Percent)    # new PWM on channel=LED_gpio frequency=38KHz
+
     print("turn on pwm by pressing button")
     input()
     p.start_pwm()
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     print("dimm pwm by pressing button")
     input()
     p.duty_cycle(50)
-    
+
     print("change pwm frequency by pressing button")
     input()
     p.change_frequency(500)
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     p.stop_pwm()
 
     print("change polarity by pressing button")
-    input()   
+    input()
     p.pwm_polarity()
 
     print("increase duty cycle but inverted so light will dim. press button to contunue")
@@ -38,10 +38,10 @@ if __name__ == "__main__":
     p.duty_cycle(25)
 
     print("stop pwm (it was inverted so it shoudl be full brightness), press button to contunue")
-    input()   
+    input()
     p.stop_pwm()
 
     print("remove object and deactivate pwm pin, press button to contunue")
     input()
     p.pwm_close()
-    del p #delete the class
+    del p  # delete the class

--- a/OPi/GPIO.py
+++ b/OPi/GPIO.py
@@ -234,6 +234,121 @@ the :py:meth:`input()` function. For example to toggle an output:
 
        GPIO.output(12, not GPIO.input(12))
 
+
+PWM
+----
+The PWM module is a hardware PWM feature, meaning that it uses the built in PWM chip
+on the single board computer rather than any software timings or threads, this should
+result in more accurate PWM signal that is less resorce taxing.
+
+PWM is created in the form of an object.
+
+1. First set up OPi.GPIO and create the object
+
+    .. code:: python
+
+       import OPi.GPIO as GPIO
+       PWM_Class = GPIO.PWM(PWM_chip, PWM_pin, frequency_Hz, Duty_Cycle_Percent)
+
+    Note currently you do not need to specify setmode before creating the class as for a GPIO
+    only the PWM_chip number and the PWM_pin.
+    The reson for this and how to find what they are is explained in the sysfs PWM section.
+
+2. Begin the PWM cycle
+
+    .. code:: python
+
+        PWM_Class.start_pwm()
+
+3. Change PWM duty Cycle
+
+    .. code:: python
+        PWM_Class.duty_cycle(50)
+
+    Note this changes the Duty cycle to 50%
+
+4. Change the frequency
+
+    .. code:: python
+        PWM_Class.change_frequency(500)
+
+    Note this changes the Frequency to 500Hz
+
+5. Stop the PWM device
+
+    .. code:: python
+        PWM_Class.stop_pwm()
+
+    Note this stops the signal by setting the duty cycle to 0%
+
+6. Change the Polarity of the signal
+
+    .. code:: python
+        PWM_Class.pwm_polarity()
+
+    Note this changes swaps the on-off times. For example a duty cycle set to 75% before
+    this will result in the signal being on 75% and off 25% of the time. After this is
+    called it would be on 25% and off 75%.
+
+7. Remove PWM Object
+
+    .. code:: python
+        PWM_Class.pwm_close()
+
+SYSFS PWM:
+----------
+The PWM module uses the linux sysfs system to access and control the PWM chip on the single
+board computer. More information can be found at:
+
+https://developer.toradex.com/knowledge-base/pwm-linux
+
+This code was written on an OrangePi PC+ so the following examples are based on that, however any single board
+computer running linux that has a pwm chip will be able to use this.
+To create a PWM object you write 0 to the file '/sys/class/pwm/pwmchip0/export'.
+By writing 0 you are creating a pwm object called pwm0 that is tied to pwm pin 0.
+This pin is RX pin of the DEBUG TTL UART pins (the middle pin of the pins between the power socket and HDMI).
+The PWM commands are then controlled by writing into the files made at '/sys/class/pwm/pwmchip0/pwm0'.
+
+Different single board computers may have pwm chip and pin names, currently the PWM pins have not been
+mapped accross different boards, hence the need to specify the chip number and pin number at the start.
+To find out what pins are available on your device you can follow the following steps:
+
+1. Switch to Super User:
+
+    .. code:: bash
+        su root
+
+2. List all pwm chips on the system:
+
+    .. code:: bash
+        ls -l /sys/class/pwm/
+
+This will show all of the pwm chips on the system for example pwmchip0. The number following pwmchip is the
+chip number used in PWM_chip. Some boards may have multiple chips, they will all be listed with that previous command.
+
+3. Find the pin(s) associated with the chip:
+
+    .. code:: bash
+        echo 0 > /sys/class/pwm/pwmchip0/export
+
+This writes '0' to the file 'export' which is under pwmchip0. If the chip has a pin 0 associated with it, an object that will
+be created that can control the pwm pin. If a pin doesn't exisit an error will come up stating 'no such device'.
+As of yet I do not know how to list out all of the available pins associated with a chip, there is a list at https://linux-sunxi.org/PIO
+however not all pwm pins listed might be readily usable. For example on the OPi PC+ GPIO PA5 (physical pin 7) is listed as being PWM1 however it
+is not accessable by default, likely it is reserved for something else and would probably require changing the DTC file before it can be accessed.
+
+The best option would be to increase the number until you find a pin. You shouldn't need to go higher than 5 for any 1 chip.
+The PWM pins dont follow the GPIO numbering system so the number are quite low.
+
+4. List the created pwm pins:
+
+    .. code:: bash
+        ls /sys/class/pwm/pwmchip0
+
+This lists all the files associated with pwmchip0. if you successfully created an object in step 3 you will see a pwm object (for example pwm0).
+The number listed after pwm is the pin number used in PWM_pin.
+
+
 Methods
 -------
 """
@@ -583,103 +698,81 @@ def cleanup(channel=None):
         sysfs.unexport(pin)
         del _exports[channel]
 
-_exports_pwm = {}
 
 class PWM:
-    
-    #To Do:
+
+    # To Do:
     # 1. Start tracking pwm cases to _exports_pwm
-    # 2. find way to check _exports against _exports_pwm to make sure there is no overlap. Dont think it is a problem for OPi pc+ but better futureproof  
-    
-    def __init__(self, channel, frequency, duty_cycle_percent, invert_polarity = False): #(pwm pin, frequency in KHz)
-        
-        if _mode is None:
-            raise RuntimeError("Mode has not been set")
-        
-        if channel in _exports: #check if there the pin is already assigned
-            raise RuntimeError("Channel {0} is already configured".format(channel))
-        
-        #if channel in _exports_pwm:
-        #    raise RuntimeError("Channel {0} is already configured as PWM pin".format(channel))
-        #else:
-        #    add channel to channel tracker
-        
-        #pin = get_gpio_pin(_mode, channel) #think needs to be changed 
-        pin = channel
+    # 2. find way to check _exports against _exports_pwm to make sure there is no overlap. Dont think it is a problem for OPi pc+ but better futureproof
+
+    def __init__(self, chip, pin, frequency, duty_cycle_percent, invert_polarity=False):  # (pwm pin, frequency in KHz)
+
+        self.chip = chip
         self.pin = pin
         self.frequency = frequency
         self.duty_cycle_percent = duty_cycle_percent
         self.invert_polarity = invert_polarity
-        
+
         try:
-            sysfs.PWM_Export(pin) #creates the pwm sysfs object
+            sysfs.PWM_Export(chip, pin)  # creates the pwm sysfs object
             if invert_polarity is True:
-                sysfs.PWM_Polarity(pin, invert = True) # invert pwm i.e the duty cycle tells you how long the cycle is off 
+                sysfs.PWM_Polarity(chip, pin, invert=True)  # invert pwm i.e the duty cycle tells you how long the cycle is off
             else:
-                sysfs.PWM_Polarity(pin, invert = False) #don't invert the pwm signal. This is the normal way its used.
-            sysfs.PWM_Enable(pin)
-            return sysfs.PWM_Frequency(pin, frequency)
-            
+                sysfs.PWM_Polarity(chip, pin, invert=False)  # don't invert the pwm signal. This is the normal way its used.
+            sysfs.PWM_Enable(chip, pin)
+            return sysfs.PWM_Frequency(chip, pin, frequency)
+
         except (OSError, IOError) as e:
             if e.errno == 16:   # Device or resource busy
-                if _gpio_warnings:
-                    warnings.warn("Channel {0} is already in use, continuing anyway. Use GPIO.setwarnings(False) to disable warnings.".format(channel), stacklevel=2)
-                #sysfs.unexport(pin) #leaving this here as a reminder to make a check. There will now be 2 types of pins that can be exported  
-                #sysfs.export(pin)
-                sysfs.PWM_Unexport(pin)
-                sysfs.PWM_Export(pin)
+                warnings.warn("Pin {0} is already in use, continuing anyway.".format(pin), stacklevel=2)
+                sysfs.PWM_Unexport(chip, pin)
+                sysfs.PWM_Export(chip, pin)
             else:
                 raise e
-                 
-    def start_pwm(self): #turn on pwm by setting the duty cycle to what the user specified  
-        return sysfs.PWM_Duty_Cycle_Percent(self.pin, self.duty_cycle_percent) #duty cycle controls the on-off
-        
-    def stop_pwm(self): #turn on pwm by setting the duty cycle to 0
-        return sysfs.PWM_Duty_Cycle_Percent(self.pin, 0) #duty cycle at 0 is the equivilant of off
-        
+
+    def start_pwm(self):  # turn on pwm by setting the duty cycle to what the user specified
+        return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, self.duty_cycle_percent)  # duty cycle controls the on-off
+
+    def stop_pwm(self):  # turn on pwm by setting the duty cycle to 0
+        return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, 0)  # duty cycle at 0 is the equivilant of off
+
     def change_frequency(self, new_frequency):
         # Order of opperations:
         # 1. convert to period
-        # 1. check if period is increasing or decreasing
-        # 2. If increasing update pwm period and then update the duty cycle period
-        # 3. If decreasing update the duty cycle period and then the pwm period
+        # 2. check if period is increasing or decreasing
+        # 3. If increasing update pwm period and then update the duty cycle period
+        # 4. If decreasing update the duty cycle period and then the pwm period
         # Why:
         # The sysfs rule for PWM is that PWM Period >= duty cycle period (in nanosecs)
-        
-        pwm_period = (1/new_frequency)*1e9
+
+        pwm_period = (1 / new_frequency) * 1e9
         pwm_period = int(round(pwm_period, 0))
-        duty_cycle = (self.duty_cycle_percent/100)*pwm_period
-        duty_cycle = int(round(duty_cycle, 0)) 
+        duty_cycle = (self.duty_cycle_percent / 100) * pwm_period
+        duty_cycle = int(round(duty_cycle, 0))
 
-        old_pwm_period = int(round((1/self.frequency)*1e9, 0))
+        old_pwm_period = int(round((1 / self.frequency) * 1e9, 0))
 
-        if (pwm_period > old_pwm_period): #if increasing
-            #update pwm freq
-            sysfs.PWM_Period(self.pin, pwm_period) #update the frequency
-            #update duty cycle
-            sysfs.PWM_Duty_Cycle(self.pin, duty_cycle)
-            
+        if (pwm_period > old_pwm_period):  # if increasing
+            sysfs.PWM_Period(self.chip, self.pin, pwm_period)  # update the pwm period
+            sysfs.PWM_Duty_Cycle(self.chip, self.pin, duty_cycle)  # update duty cycle
+
         else:
-            #update duty cycle
-            sysfs.PWM_Duty_Cycle(self.pin, duty_cycle)
-            #update pwm freq
-            sysfs.PWM_Period(self.pin, pwm_period)
-            
-        self.frequency = new_frequency #update the frequency
-        
-    def duty_cycle(self, duty_cycle_percent): # in percentage (0-100)
-        try:
-            if (0 <= duty_cycle_percent <= 100):
-                self.duty_cycle_percent = duty_cycle_percent
-                return sysfs.PWM_Duty_Cycle_Percent(self.pin, self.duty_cycle_percent) 
-        except:
-            print("error please enter a value between 0 and 100")
-               
-    def pwm_polarity(self): #invert the polarity of the pwm 
-        sysfs.PWM_Disable(self.pin)
-        sysfs.PWM_Polarity(self.pin, invert = not(self.invert_polarity))
-        sysfs.PWM_Enable(self.pin)
+            sysfs.PWM_Duty_Cycle(self.chip, self.pin, duty_cycle)  # update duty cycle
+            sysfs.PWM_Period(self.chip, self.pin, pwm_period)  # update pwm freq
+
+        self.frequency = new_frequency  # update the frequency
+
+    def duty_cycle(self, duty_cycle_percent):  # in percentage (0-100)
+        if (0 <= duty_cycle_percent <= 100):
+            self.duty_cycle_percent = duty_cycle_percent
+            return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, self.duty_cycle_percent)
+        else:
+            raise Exception("Duty cycle must br between 0 and 100. Current value: {0} is out of bounds".format(duty_cycle_percent))
+
+    def pwm_polarity(self):  # invert the polarity of the pwm
+        sysfs.PWM_Disable(self.chip, self.pin)
+        sysfs.PWM_Polarity(self.chip, self.pin, invert=not(self.invert_polarity))
+        sysfs.PWM_Enable(self.chip, self.pin)
 
     def pwm_close(self):
-        sysfs.PWM_Unexport(self.pin)
-        
+        sysfs.PWM_Unexport(self.chip, self.pin)

--- a/OPi/GPIO.py
+++ b/OPi/GPIO.py
@@ -702,10 +702,22 @@ def cleanup(channel=None):
 class PWM:
 
     # To Do:
-    # 1. Start tracking pwm cases to _exports_pwm
-    # 2. find way to check _exports against _exports_pwm to make sure there is no overlap. Dont think it is a problem for OPi pc+ but better futureproof
+    # 1. Start tracking pwm cases to  list like _exports say _exports_pwm
+    # 2. find way to check _exports against _exports_pwm to make sure there is no overlap.
+    # 3. Create map of pwm pins to various boards.
 
     def __init__(self, chip, pin, frequency, duty_cycle_percent, invert_polarity=False):  # (pwm pin, frequency in KHz)
+
+        """
+        Setup the PWM object to control.
+
+        :param chip: the pwm chip number you wish to use.
+        :param pin: the pwm pin number you wish to use.
+        :param frequency: the frequency of the pwm signal in hertz.
+        :param duty_cycle_percent: the duty cycle percentage.
+        :param invert_polarity: invert the duty cycle.
+            (:py:attr:`True` or :py:attr:`False`).
+        """
 
         self.chip = chip
         self.pin = pin
@@ -731,9 +743,15 @@ class PWM:
                 raise e
 
     def start_pwm(self):  # turn on pwm by setting the duty cycle to what the user specified
+        """
+        Start PWM Signal.
+        """
         return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, self.duty_cycle_percent)  # duty cycle controls the on-off
 
     def stop_pwm(self):  # turn on pwm by setting the duty cycle to 0
+        """
+        Stop PWM Signal.
+        """
         return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, 0)  # duty cycle at 0 is the equivilant of off
 
     def change_frequency(self, new_frequency):
@@ -744,6 +762,12 @@ class PWM:
         # 4. If decreasing update the duty cycle period and then the pwm period
         # Why:
         # The sysfs rule for PWM is that PWM Period >= duty cycle period (in nanosecs)
+
+        """
+        Change the frequency of the signal.
+
+        :param new_frequency: the new PWM frequency.
+        """
 
         pwm_period = (1 / new_frequency) * 1e9
         pwm_period = int(round(pwm_period, 0))
@@ -763,6 +787,12 @@ class PWM:
         self.frequency = new_frequency  # update the frequency
 
     def duty_cycle(self, duty_cycle_percent):  # in percentage (0-100)
+        """
+        Change the duty cycle of the signal.
+
+        :param duty_cycle_percent: the new PWM duty cycle as a percentage.
+        """
+        
         if (0 <= duty_cycle_percent <= 100):
             self.duty_cycle_percent = duty_cycle_percent
             return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, self.duty_cycle_percent)
@@ -770,9 +800,15 @@ class PWM:
             raise Exception("Duty cycle must br between 0 and 100. Current value: {0} is out of bounds".format(duty_cycle_percent))
 
     def pwm_polarity(self):  # invert the polarity of the pwm
+        """
+        Invert the signal.
+        """
         sysfs.PWM_Disable(self.chip, self.pin)
         sysfs.PWM_Polarity(self.chip, self.pin, invert=not(self.invert_polarity))
         sysfs.PWM_Enable(self.chip, self.pin)
 
     def pwm_close(self):
+        """
+        remove the object from the system.
+        """
         sysfs.PWM_Unexport(self.chip, self.pin)

--- a/OPi/GPIO.py
+++ b/OPi/GPIO.py
@@ -792,7 +792,7 @@ class PWM:
 
         :param duty_cycle_percent: the new PWM duty cycle as a percentage.
         """
-        
+
         if (0 <= duty_cycle_percent <= 100):
             self.duty_cycle_percent = duty_cycle_percent
             return sysfs.PWM_Duty_Cycle_Percent(self.chip, self.pin, self.duty_cycle_percent)

--- a/OPi/sysfs.py
+++ b/OPi/sysfs.py
@@ -84,51 +84,52 @@ def edge(pin, trigger):
     with open(path, "w") as fp:
         fp.write(opts[trigger])
 
-# Hardware PWM functionality: 
+# Hardware PWM functionality:
 #   resources: https://developer.toradex.com/knowledge-base/pwm-linux    &    https://www.faschingbauer.me/trainings/material/soup/hardware/pwm/topic.html
 
-def PWM_Export(pin): #some chips will have more than 1 pwm chip. the OPi PC+ only has 1 called pwmchip0. To list what chips are available use 'ls -l /sys/class/pwm'
-    path = "/sys/class/pwm/pwmchip0/export"
-    await_permissions(path)
-    with open(path, "w") as fp:
-        fp.write(str(pin)) 
- 
-        
-def PWM_Unexport(pin):
-    path = "/sys/class/pwm/pwmchip0/unexport"
+
+def PWM_Export(chip, pin):  # some chips will have more than 1 pwm chip. the OPi PC+ only has 1 called pwmchip0. To list what chips are available use 'ls -l /sys/class/pwm'
+    path = "/sys/class/pwm/pwmchip{0}/export".format(chip)
     await_permissions(path)
     with open(path, "w") as fp:
         fp.write(str(pin))
 
-        
-def PWM_Enable(pin): #enables PWM so that it can be controlled 
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/enable".format(pin)         
+
+def PWM_Unexport(chip, pin):
+    path = "/sys/class/pwm/pwmchip{0}/unexport".format(chip)
+    await_permissions(path)
+    with open(path, "w") as fp:
+        fp.write(str(pin))
+
+
+def PWM_Enable(chip, pin):  # enables PWM so that it can be controlled
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/enable".format(chip, pin)
     await_permissions(path)
     with open(path, "w") as fp:
         fp.write(str(1))
- 
-        
-def PWM_Disable(pin): #disables PWM
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/enable".format(pin)         
+
+
+def PWM_Disable(chip, pin):  # disables PWM
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/enable".format(chip, pin)
     await_permissions(path)
     with open(path, "w") as fp:
         fp.write(str(0))
-        
 
-def PWM_Polarity(pin, invert = False): #inverts the pwm signal. i.e rather than a higher duty cycle being brighter it becomes dimmer. Import to add as sometimes inverted is the defualt
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/polarity".format(pin)  #important! pwm must be disables before inverting or it wont work
+
+def PWM_Polarity(chip, pin, invert=False):  # inverts the pwm signal. i.e rather than a higher duty cycle being brighter it becomes dimmer. Import to add as sometimes inverted is the defualt
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/polarity".format(chip, pin)  # important! pwm must be disables before inverting or it wont work
     await_permissions(path)
-    if invert is True:    
+    if invert is True:
         with open(path, "w") as fp:
-            fp.write(str("inversed"))  
-    else: 
+            fp.write(str("inversed"))
+    else:
         with open(path, "w") as fp:
-            fp.write(str("normal"))          
-        
-        
-def PWM_Period(pin, pwm_period): #in nanoseconds
-    duty_cycle_path = "/sys/class/pwm/pwmchip0/pwm{0}/duty_cycle".format(pin)
-    with open(duty_cycle_path, "r") as fp: #read the current period to compare. this is necessary as the duty cycle has to be less than the period.
+            fp.write(str("normal"))
+
+
+def PWM_Period(chip, pin, pwm_period):  # in nanoseconds
+    duty_cycle_path = "/sys/class/pwm/pwmchip{0}/pwm{1}/duty_cycle".format(chip, pin)
+    with open(duty_cycle_path, "r") as fp:  # read the current period to compare. this is necessary as the duty cycle has to be less than the period.
         current_duty_cycle_period = int(fp.read())
         fp.close()
     if (current_duty_cycle_period > pwm_period):
@@ -136,43 +137,42 @@ def PWM_Period(pin, pwm_period): #in nanoseconds
         print("New Duty Cyce = ", current_duty_cycle_period, " Current PWM Period = ", pwm_period)
         os.error
 
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/period".format(pin)
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/period".format(chip, pin)
     await_permissions(path)
-    with open(path, "w") as fp: #pretty sure this 
-        fp.write(str(pwm_period)) 
-    
+    with open(path, "w") as fp:  # pretty sure this
+        fp.write(str(pwm_period))
 
-        
-def PWM_Frequency(pin, pwm_frequency): #in Hz
-    pwm_period = (1/pwm_frequency)*1e9 #convert freq to time in nanoseconds
+
+def PWM_Frequency(chip, pin, pwm_frequency):  # in Hz
+    pwm_period = (1 / pwm_frequency) * 1e9  # convert freq to time in nanoseconds
     pwm_period = int(round(pwm_period, 0))
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/period".format(pin)
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/period".format(chip, pin)
     await_permissions(path)
-    with open(path, "w") as fp: #pretty sure this 
-        fp.write(str(pwm_period)) 
-        
+    with open(path, "w") as fp:  # pretty sure this
+        fp.write(str(pwm_period))
 
-def PWM_Duty_Cycle_Percent(pin, Duty_cycle): #in percentage
-    PWM_period_path = "/sys/class/pwm/pwmchip0/pwm{0}/period".format(pin)    
-    with open(PWM_period_path, "r") as fp: #read the current period to compare. this is necessary as the duty cycle has to be less than the period.
+
+def PWM_Duty_Cycle_Percent(chip, pin, Duty_cycle):  # in percentage
+    PWM_period_path = "/sys/class/pwm/pwmchip{0}/pwm{1}/period".format(chip, pin)
+    with open(PWM_period_path, "r") as fp:  # read the current period to compare. this is necessary as the duty cycle has to be less than the period.
         current_period = int(fp.read())
         fp.close()
-    new_duty_cycle =  int(round(Duty_cycle/100 * current_period, 0))
-    
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/duty_cycle".format(pin) 
-    with open(path, "w") as fp: #pretty sure this 
-        fp.write(str(new_duty_cycle)) 
-        
+    new_duty_cycle = int(round(Duty_cycle / 100 * current_period, 0))
 
-def PWM_Duty_Cycle(pin, Duty_cycle): #in nanoseconds
-    PWM_period_path = "/sys/class/pwm/pwmchip0/pwm{0}/period".format(pin)    
-    with open(PWM_period_path, "r") as fp: #read the current period to compare. this is necessary as the duty cycle has to be less than the period.
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/duty_cycle".format(chip, pin)
+    with open(path, "w") as fp:  # pretty sure this
+        fp.write(str(new_duty_cycle))
+
+
+def PWM_Duty_Cycle(chip, pin, Duty_cycle):  # in nanoseconds
+    PWM_period_path = "/sys/class/pwm/pwmchip{0}/pwm{1}/period".format(chip, pin)
+    with open(PWM_period_path, "r") as fp:  # read the current period to compare. this is necessary as the duty cycle has to be less than the period.
         current_period = int(fp.read())
-        fp.close()   
-    if (Duty_cycle>current_period):
+        fp.close()
+    if (Duty_cycle > current_period):
         print("Error the new duty cycle period must be less than or equal to the PWM Period: ", current_period)
         print("New Duty Cyce = ", Duty_cycle, " Current PWM Period = ", current_period)
         os.error
-    path = "/sys/class/pwm/pwmchip0/pwm{0}/duty_cycle".format(pin) 
-    with open(path, "w") as fp: #pretty sure this 
-        fp.write(str(Duty_cycle)) 
+    path = "/sys/class/pwm/pwmchip{0}/pwm{1}/duty_cycle".format(chip, pin)
+    with open(path, "w") as fp:  # pretty sure this
+        fp.write(str(Duty_cycle))

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ References
 * https://jsfiddle.net/tuav7f6q/2/
 * https://www.mysensors.org/build/orange
 * https://kaspars.net/blog/linux/orange-pi-zero-gpio
+* https://developer.toradex.com/knowledge-base/pwm-linux
 
 License
 -------

--- a/orangepi/pi4.py
+++ b/orangepi/pi4.py
@@ -39,7 +39,7 @@ BOARD = {
     26: 149,  # GPIO4_C5
     27: 64,   # I2C2_SDA
     28: 65,   # I2C2_SCL
- }
+}
 
 # No reason for BCM mapping, keeping it for compatibility
 BCM = BOARD

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -1,0 +1,40 @@
+import pytest
+import OPi.GPIO as GPIO
+
+
+def test_pwm_wrong_chip_pin():
+
+    # Test for a chip-pin combo that does not exist
+    PWM_chip = 99
+    PWM_pin = 99
+    frequency_Hz = 500
+    Duty_Cycle_Percent = 50
+
+    with pytest.raises(Exception) as ex:
+
+        GPIO.PWM(PWM_chip, PWM_pin, frequency_Hz, Duty_Cycle_Percent)
+        if ex.errno == 2:
+            assert str(ex.value) == "FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/pwm/pwmchip{0}/export'".format(PWM_chip)
+        elif ex.errno == 19:
+            assert str(ex.value) == "OSError: [Errno 19] No such device"
+
+
+def test_invalid_duty_cycle():
+
+    PWM_chip = 0
+    PWM_pin = 0
+    frequency_Hz = 500
+    Duty_Cycle_Percent_high = 150
+    Duty_Cycle_Percent_low = -50
+
+    with pytest.raises(Exception) as ex:
+        p = GPIO.PWM(PWM_chip, PWM_pin, frequency_Hz, Duty_Cycle_Percent_high)
+        p.duty_cycle(150)
+        assert str(ex.value) == "Duty cycle must br between 0 and 100. Current value: {0} is out of bounds".format(Duty_Cycle_Percent_high)
+        p.pwm_close()
+
+    with pytest.raises(Exception) as ex:
+        p = GPIO.PWM(PWM_chip, PWM_pin, frequency_Hz, Duty_Cycle_Percent_low)
+        p.duty_cycle(-50)
+        assert str(ex.value) == "Duty cycle must br between 0 and 100. Current value: {0} is out of bounds".format(Duty_Cycle_Percent_low)
+        p.pwm_close()


### PR DESCRIPTION
Added hardware PWM using sysfs based on https://developer.toradex.com/knowledge-base/pwm-linux

It has been created as a class in order to create better tracking of PWM parameters, this is important as PWM has more features than a standard GPIO output.

This was developed and tested on an OrangePi PC Plus and works :smile:  however was not tested on other boards. Likely though it will work on any H3 chip. The only thing to bare in mind is that you need to use PWM0 pin. On the OPi PC+ board this is the middle pin of the Debug TTL UART pins, located between the power and HDMI. The documentation mentions a PWM1 at pin A6 (physical pin 7) but I could not figure out how to access that. I believe the DTC will have to be changed to access it.

The commands that are used to create and control the PWM signal are:
p = GPIO.PWM(PWM_pin, frequency_Hz, Duty_Cycle_Percent) to create the object
p.start_pwm()      To begin the output
p.duty_cycle(Duty_Cycle_Percent)  To adjust the duty cycle
p.change_frequency(frequency_Hz) To change the PWM frequency
p.pwm_polarity() To adjust the polarity, ie. changing duty cycle from percentage on to percentage off or vice versa
p.stop_pwm() To stop the PWM by setting the duty cycle to 0
p.pwm_close() To completely remove the PWM sysfs object.

For an OrangePi H3 board such as the PC + use PWM_pin = 0. As the PWM setup is different to the GPIO setup I didn't integrate the pin map present in this library. Its not an inconvenience however as this will likely be the same for all OPi H3 boards, but if you want to check what number you need to put in use:
"ls -l /sys/class/pwm/" This will show you all the PWMchips are on your system. it will be something like pwmchip0.
"echo 0 > /sys/class/pwm/pwmchip0/export"  this will create the PWM object. if an error returns saying no such device try 1 and so on. They are generally low numbers less than 5.
"ls /sys/class/pwm/pwmchip0" this will list all of the controls as well as the PWM object that was created.  The object is should  be called PWM0 (or PWM-whatever number worked)

The number following the PWM object name is the pin number you use in GPIO.PWM(PWM_pin, frequency_Hz, Duty_Cycle_Percent). It probably wouldn't be too difficult to make a list of pins for the various boards and use that as the pin mapping but I haven't.

I tried to leave a lot of comments as I was going along so hopefully the changes should make sense (this is my first time trying to contribute to someone's code so be nice 😉 ), I've added a demo to maybe showcase a bit better what is happening. 